### PR TITLE
Support systemwide config

### DIFF
--- a/chatgpt.py
+++ b/chatgpt.py
@@ -34,7 +34,7 @@ def load_config() -> dict:
     if os.getenv("XDG_CONFIG_HOME"):
         config_dir = os.getenv("XDG_CONFIG_HOME") + "/chatgpt-cli"
     elif os.getenv("HOME"):
-        config_dir = os.environ("HOME") + "/.config/chagpt-cli"
+        config_dir = os.getenv("HOME") + "/.config/chagpt-cli"
 
     if config_dir:
         config_file = config_dir + "/config.yaml"

--- a/chatgpt.py
+++ b/chatgpt.py
@@ -32,7 +32,7 @@ def load_config() -> dict:
     config = {"api-key": "", "model": "gpt-3.5-turbo"}
 
     if os.getenv("XDG_CONFIG_HOME"):
-        config_dir = os.getenv("XDG_CONFIG_HOME") + "/chatgt-cli"
+        config_dir = os.getenv("XDG_CONFIG_HOME") + "/chatgpt-cli"
     elif os.getenv("HOME"):
         config_dir = os.environ("HOME") + "/.config/chagpt-cli"
 

--- a/chatgpt.py
+++ b/chatgpt.py
@@ -46,7 +46,7 @@ def load_config() -> dict:
             config = yaml.load(file, Loader=yaml.FullLoader)
 
     if not config["api-key"].startswith("sk"):
-        config["api-key"] = os.getenv("OAI_SECRET_KEY")
+        config["api-key"] = os.getenv("OAI_SECRET_KEY", "fail")
     while not config["api-key"].startswith("sk"):
         config["api-key"] = input(
             "Enter your OpenAI Secret Key (should start with 'sk-')\n"


### PR DESCRIPTION
It will read configuration in this order:

-  `$XDG_CONFIG_HOME/chatgpt-cli/config.yaml`                   
-  `$HOME/.config/chatgpt-cli/config.yaml`
- `config.yaml` *(Note that isn't ideal  because an arbitrary dir may contain an arbitrary config file with the same name).*

And then will read `api-key` case it isn't set:

- from env var
- from interactive input
                                                                                                                  