### PR TITLE
Update PyYaml version so it works with python-3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pathspec==0.11.0
 platformdirs==3.1.0
 prompt-toolkit==3.0.38
 Pygments==2.14.0
-PyYAML==6.0
+PyYAML>=6.0,<6.1
 requests==2.28.2
 rich==13.4.0
 tomli==2.0.1


### PR DESCRIPTION
Package installation was failing for python-3.12, because PyYaml-6.0 doesn't work with python-3.12, though they fixed it in PyYaml-6.0.1