### PR TITLE
non-interactive markdown changes

### DIFF
--- a/src/chatgpt.py
+++ b/src/chatgpt.py
@@ -229,12 +229,14 @@ def start_prompt(session: PromptSession, config: dict) -> None:
         message_response = response["choices"][0]["message"]
         usage_response = response["usage"]
 
-        console.line()
+        if not config["non_interactive"]:
+            console.line()
         if config["markdown"]:
             console.print(Markdown(message_response["content"].strip()))
         else:
-            console.print(message_response["content"].strip())
-        console.line()
+            print(message_response["content"].strip())
+        if not config["non_interactive"]:
+            console.line()
 
         # Update message history and token counters
         messages.append(message_response)
@@ -369,6 +371,12 @@ def main(
         config["model"] = model.strip()
 
     config["non_interactive"] = non_interactive
+    
+    # Do not emit markdown in this case; ctrl character formatting interferes in several contexts including json
+    # output.
+    if config["non_interactive"]:
+        config["markdown"] = False
+    
     config["json_mode"] = json_mode
 
     # Run the display expense function when exiting the script


### PR DESCRIPTION
@marcolardera the latest changes with the logger and markdown did end up inadvertently break non-interactive mode.

The core issue is that the console library is doing all sorts of smart things to detect the console and then emitting control characters corresponding to colors and such.  This breaks the pipeline because the output is no longer what's expected.

Here's a proof of concept showing the issue:  you can do this:

```
$ echo "Generate a haiku about a banana as a json object in 3 lines, with 3 keys, line1, line2, line3" | python3 src/chatgpt.py -n --json -m gpt-4-1106-preview 
Warning: Input is not a terminal (fd=0).
{
  "line1": "Yellow fruit in hand,",
  "line2": "Peel whispers soft to the floor,",
  "line3": "Sweetness swirls within."
}
```

OK, so I get a nice JSON haiku.  But it typically has markdown syntax highlighting, so if you run the same thing and pipe the JSON result from OpenAI through another tool that works with json like `jq`, it breaks because the result isn't JSON.

```
jq: parse error: Invalid string: control characters from U+0000 through U+001F must be escaped at line 6, column 31
```

The fix is to make it possible in non-interactive mode to output pure dumb text with no special colors, formatting/markdown, etc.  I've tried to make both of these possible, but `-n` is intentionally turning off all markdown related behavior.

Another thing I noticed but didn't fix in this PR is that the "markdown" key has been introduced in the config file, but you can't change it via command-line flags.