### PR TITLE
Fix pip install failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,5 @@ authors = [
 ]
 description = "Simple yet effective command line client for chatting with ChatGPT using the official API." 
 readme = "README.md"
-
 requires-python = ">=3.10"
+dynamic = ["scripts", "dependencies"]


### PR DESCRIPTION
While I was working on #52, I encountered the issue that was reported in #51. Specifically, pip install would fail to put `chatgpt-cli` in bin. Similarly, pipx failed with the error listed below.

> No apps associated with package chatgpt-cli or its dependencies. If you are attempting to install a library, pipx should not be used. Consider using pip or a similar tool instead.

The root cause was revealed when I ran `pip install -v` on the repo. There were some errors in the verbose output that explained what was going on. They are listed below.


```
          ********************************************************************************
          The following seems to be defined outside of `pyproject.toml`:

          `scripts = ['chatgpt-cli = chatgpt:main']`

          According to the spec (see the link below), however, setuptools CANNOT
          consider this value unless `scripts` is listed as `dynamic`.

          https://packaging.python.org/en/latest/specifications/declaring-project-metadata/

          To prevent this problem, you can list `scripts` under `dynamic` or alternatively
          remove the `[project]` table from your file and rely entirely on other means of
          configuration.
          ********************************************************************************
```

```
          ********************************************************************************
          The following seems to be defined outside of `pyproject.toml`:

          `dependencies = ['black == 23.1.0', 'certifi == 2022.12.7', 'charset-normalizer == 3.0.1', 'click == 8.1.3', 'idna == 3.4', 'markdown-it-py == 2.2.0', 'mdurl == 0.1.2', 'mypy-extensions == 1.0.0', 'packaging == 23.0', 'pathspec == 0.11.0', 'platformdirs == 3.1.0', 'prompt-toolkit == 3.0.38', 'Pygments == 2.14.0', 'PyYAML >= 6.0, < 6.1', 'requests == 2.28.2', 'rich == 13.4.0', 'tomli == 2.0.1', 'typing_extensions == 4.6.2', 'urllib3 == 1.26.14', 'wcwidth == 0.2.6', 'xdg-base-dirs ~= 6.0.0']`

          According to the spec (see the link below), however, setuptools CANNOT
          consider this value unless `dependencies` is listed as `dynamic`.

          https://packaging.python.org/en/latest/specifications/declaring-project-metadata/

          To prevent this problem, you can list `dependencies` under `dynamic` or alternatively
          remove the `[project]` table from your file and rely entirely on other means of
          configuration.
          ********************************************************************************
```

In short, what these errors imply is that setuptools is ignoring the entry points and the list of dependencies that are listed in `setup.cfg`. Adding a [project] table to `pyproject.toml` will override the configurations in `setup.cfg` unless the properties are explicitly marked as dynamic in the `pyproject.toml` file.

By marking scripts and dependencies as dynamic, these warnings are eliminated, and pip install works as expected.