### PR TITLE
Fix for path creation

### DIFF
--- a/src/chatgpt.py
+++ b/src/chatgpt.py
@@ -81,8 +81,10 @@ def load_config(config_file: str) -> dict:
     If the config file is missing, create one with default values.
     If the config file is present but missing keys, populate them with defaults.
     """
+    print(Path(config_file))
     # If the config file does not exist, create one with default configurations
     if not Path(config_file).exists():
+        os.makedirs(os.path.dirname(config_file), exist_ok=True)
         with open(config_file, "w") as file:
             yaml.dump(DEFAULT_CONFIG, file, default_flow_style=False)
         logger.info(f"New config file initialized: [green bold]{config_file}")

--- a/src/chatgpt.py
+++ b/src/chatgpt.py
@@ -80,8 +80,7 @@ def load_config(config_file: str) -> dict:
     Read a YAML config file and returns its content as a dictionary.
     If the config file is missing, create one with default values.
     If the config file is present but missing keys, populate them with defaults.
-    """
-    print(Path(config_file))
+    """    
     # If the config file does not exist, create one with default configurations
     if not Path(config_file).exists():
         os.makedirs(os.path.dirname(config_file), exist_ok=True)


### PR DESCRIPTION
Sometimes, starting the CLI will fail with "Config file not found".  This is because python's config file location is often something like:

`/Users/davidallen/.config/chatgpt-cli/config.yaml`

But if the intermediate `.config` directory doesn't exist, the attempt to write config.yaml will fail.

The fix is to create intermediate directories whenever forced to create a config file for the first time.