### PR TITLE
Add link to copy-to-chat gist in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ JSON Mode is enabled using the `--json` (or `-j`) flag. This forces ChatGPT to a
 
 Also check the [OpenAI Documentation](https://platform.openai.com/docs/guides/text-generation/json-mode).
 
-## Copy selection as context (Linux)
+## External tools
+
+### Copy selection as context (Linux)
 
 On Linux using XWindows, you can conveniently start a chat with any text you have highlighted in any application as the provided context. [This gist](https://gist.github.com/dwymark/df4e77c4e9fc33608bf22f1288d9195e) shows how this can be done on XFCE using `xclip`.
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ JSON Mode is enabled using the `--json` (or `-j`) flag. This forces ChatGPT to a
 
 Also check the [OpenAI Documentation](https://platform.openai.com/docs/guides/text-generation/json-mode).
 
+## Copy selection as context (Linux)
+
+On Linux using XWindows, you can conveniently start a chat with any text you have highlighted in any application as the provided context. [This gist](https://gist.github.com/dwymark/df4e77c4e9fc33608bf22f1288d9195e) shows how this can be done on XFCE using `xclip`.
+
 ## Contributing to this project
 
 Please read [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
I wrote a bash script that allows me to send text that I have highlighted to a new chatgpt-cli session. I bind this to a keyboard shortcut, which allows me to select any text (i.e., a function definition) and immediately start a new chat session with that snippet as context. I find this a very convenient trick, so I wanted to share it, but I wasn't sure the best way to do so. I put my script into a gist with some instructions on how I've set it up on my system, and I linked to it in the README near the bottom.