### PR TITLE
Update chatgpt.py: fix `open()` char encoding bug

### DIFF
--- a/src/chatgpt.py
+++ b/src/chatgpt.py
@@ -84,12 +84,12 @@ def load_config(config_file: str) -> dict:
     # If the config file does not exist, create one with default configurations
     if not Path(config_file).exists():
         os.makedirs(os.path.dirname(config_file), exist_ok=True)
-        with open(config_file, "w") as file:
+        with open(config_file, "w", encoding= "utf-8") as file:
             yaml.dump(DEFAULT_CONFIG, file, default_flow_style=False)
         logger.info(f"New config file initialized: [green bold]{config_file}")
 
     # Load existing config
-    with open(config_file) as file:
+    with open(config_file, encoding= "utf-8") as file:
         config = yaml.load(file, Loader=yaml.FullLoader)
 
     # Update the loaded config with any default values that are missing
@@ -104,7 +104,7 @@ def load_history_data(history_file: str) -> dict:
     """
     Read a session history json file and return its content
     """
-    with open(history_file) as file:
+    with open(history_file, encoding= "utf-8") as file:
         content = json.loads(file.read())
 
     return content
@@ -136,7 +136,7 @@ def save_history(
     """
     Save the conversation history in JSON format
     """
-    with open(os.path.join(SAVE_FOLDER, SAVE_FILE), "w") as f:
+    with open(os.path.join(SAVE_FOLDER, SAVE_FILE), "w", encoding= "utf-8") as f:
         json.dump(
             {
                 "model": model,


### PR DESCRIPTION
***regarding issue [#57](https://github.com/marcolardera/chatgpt-cli/issues/57)***

Although I set all open() default encodings to "utf-8" explicitly  

here is the main lines in [`chatgpt.py`](https://github.com/marcolardera/chatgpt-cli/blob/3bd6255edd619fccd8f51d328ef695fa81e51f3a/src/chatgpt.py) that directly caused the bug:

* [#139](https://github.com/marcolardera/chatgpt-cli/blob/3bd6255edd619fccd8f51d328ef695fa81e51f3a/src/chatgpt.py#L139)

* Also in case you asked GPT something like 'what was my last prompts' (given you opened using `python chatgpt.py -r last` switch for example)  this line may cause the same bug if your `GPT-cli` could actually resume the previous session and see previous prompts and resend them to you!
[#107](https://github.com/marcolardera/chatgpt-cli/blob/3bd6255edd619fccd8f51d328ef695fa81e51f3a/src/chatgpt.py#L107)