### PR TITLE
Use environment variable for OPENAI_BASE_ENDPOINT

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chatgpt-cli"
-version = "0.2.3"
+version = "0.2.4"
 authors = [
     { name = "Marco Lardera", email = "larderamarco@hotmail.com" }
 ]

--- a/src/chatgpt.py
+++ b/src/chatgpt.py
@@ -29,7 +29,7 @@ SAVE_FOLDER = BASE / "session-history"
 SAVE_FILE = (
     "chatgpt-session-" + datetime.datetime.now().strftime("%Y%m%d-%H%M%S") + ".json"
 )
-OPENAI_BASE_ENDPOINT = "https://api.openai.com/v1"
+OPENAI_BASE_ENDPOINT = os.environ.get('OPENAI_BASE_ENDPOINT', "https://api.openai.com/v1")
 ENV_VAR = "OPENAI_API_KEY"
 
 # Azure price is not accurate, it depends on your subscription

--- a/src/chatgpt.py
+++ b/src/chatgpt.py
@@ -29,7 +29,7 @@ SAVE_FOLDER = BASE / "session-history"
 SAVE_FILE = (
     "chatgpt-session-" + datetime.datetime.now().strftime("%Y%m%d-%H%M%S") + ".json"
 )
-OPENAI_BASE_ENDPOINT = os.environ.get('OPENAI_BASE_ENDPOINT', "https://api.openai.com/v1")
+OPENAI_BASE_ENDPOINT = os.environ.get("OPENAI_BASE_ENDPOINT", "https://api.openai.com/v1")
 ENV_VAR = "OPENAI_API_KEY"
 
 # Azure price is not accurate, it depends on your subscription


### PR DESCRIPTION
### Summary:
This PR introduces the use of environment variable for setting the `OPENAI_BASE_ENDPOINT`. It gives the users optional flexibility to set the endpoint URL from the environment variable. If not provided, the default URL remains as "https://api.openai.com/v1".

### Modifications:
- `OPENAI_BASE_ENDPOINT` is now grabbed from the environment variable if available.