### PR TITLE
o1 models: pricing, and they don't support system messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ ChatGPT CLI, by default, uses the original `gpt-3.5-turbo` model. In order to us
 | `gpt-4-turbo`        | 0.01                  | 0.03                  |
 | `gpt-4o`             | 0.005                 | 0.015                 |
 | `o1-mini`            | 0.003                 | 0.012                 |
-| `o1-preview          | 0.015                 | 0.06                  |
+| `o1-preview`         | 0.015                 | 0.06                  |
 
 
 Pricing is calculated as $/1000 tokens.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ ChatGPT CLI, by default, uses the original `gpt-3.5-turbo` model. In order to us
 | `gpt-4-0125-preview` | 0.01                  | 0.03                  |
 | `gpt-4-turbo`        | 0.01                  | 0.03                  |
 | `gpt-4o`             | 0.005                 | 0.015                 |
+| `o1-mini`            | 0.003                 | 0.012                 |
+| `o1-preview          | 0.015                 | 0.06                  |
+
 
 Pricing is calculated as $/1000 tokens.
 

--- a/src/chatgpt.py
+++ b/src/chatgpt.py
@@ -53,7 +53,9 @@ PRICING_RATE = {
     "gpt-4-0125-preview": {"prompt": 0.01, "completion": 0.03},
     "gpt-4-turbo-preview": {"prompt": 0.01, "completion": 0.03},
     "gpt-4o": {"prompt": 0.0025, "completion": 0.01},
-    "gpt-4o-mini": {"prompt": 0.00015, "completion": 0.0006}
+    "gpt-4o-mini": {"prompt": 0.00015, "completion": 0.0006},
+    "o1-mini": {"prompt": 0.003, "completion": 0.012},
+    "o1-preview": {"prompt": 0.015, "completion": 0.06},
 }
 
 logger = logging.getLogger("rich")
@@ -563,7 +565,7 @@ def main(
     logger.info(f"Model in use: [green bold]{model}", extra={"highlighter": None})
 
     # Add the system message for code blocks in case markdown is enabled in the config file
-    if config["markdown"]:
+    if config["markdown"] and not model.startswith("o1"):
         add_markdown_system_message()
 
     # Context from the command line option


### PR DESCRIPTION
- Added pricing estimates for o1 models
- Excluded o1 models from default markdown message, as they don't support `system` messages. (API rejects even newer and supposedly supported `developer` messages with `Unsupported value: 'messages[0].role' does not support \'developer\' with this model.`, so I just discard that for now.)